### PR TITLE
Pin to version 0.4.0 of SDG Translations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ jekyll_get_json:
     # Replace my-github-org and open-sdg-data-starter as needed.
     json: 'https://armstat.github.io/sdg-data-armenia/staging/meta/schema.json'
   - data: translations
-    json: 'https://open-sdg.github.io/sdg-translations/translations.json'
+    json: 'https://open-sdg.github.io/sdg-translations/translations-0.4.0.json'
 
 analytics:
   ga_prod: ''

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -30,7 +30,7 @@ jekyll_get_json:
     # Replace my-github-org and open-sdg-data-starter as needed.
     json: 'https://armstat.github.io/sdg-data-armenia/prod/meta/schema.json'
   - data: translations
-    json: 'https://open-sdg.github.io/sdg-translations/translations.json'
+    json: 'https://open-sdg.github.io/sdg-translations/translations-0.4.0.json'
 
 analytics:
   ga_prod: 'UA-4464980-1'


### PR DESCRIPTION
To avoid unexpected changes, let's "pin" to a specific version of SDG Translations.