### PR TITLE
Pin translations to version 0.8.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ environment: staging
 # Replace my-github-org and open-sdg-data-starter as needed.
 remote_data_prefix: "https://armstat.github.io/sdg-data-armenia/staging"
 remote_translations:
-  - 'https://open-sdg.github.io/sdg-translations/translations.json'
+  - 'https://open-sdg.github.io/sdg-translations/translations-0.8.3.json'
 
 analytics:
   ga_prod: ''


### PR DESCRIPTION
This is a bit safer, in case any changes happen in the master branch of sdg-translations.